### PR TITLE
ci: bump Noir toolchain to 1.0.0-beta.22

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        toolchain: [1.0.0-beta.20]
+        toolchain: [1.0.0-beta.22]
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4
@@ -34,7 +34,7 @@ jobs:
       - name: Install Nargo
         uses: noir-lang/noirup@v0.1.4
         with:
-          toolchain: 1.0.0-beta.20
+          toolchain: 1.0.0-beta.22
 
       - name: Run formatter
         run: nargo fmt --check


### PR DESCRIPTION
## Summary
- Updates CI test and format jobs to use Noir `1.0.0-beta.22` (from `beta.20`).
- Verified locally: all 21 tests pass and `nargo fmt --check` is clean on beta 22.

## Test plan
- [x] `nargo test` on `1.0.0-beta.22`
- [x] `nargo fmt --check` on `1.0.0-beta.22`
- [ ] CI passes on this PR


Made with [Cursor](https://cursor.com)